### PR TITLE
allows WaitIO() to reuse the []OpResult slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import (
 func echoServer(w *gaio.Watcher) {
         for {
                 // loop wait for any IO events
-                results, err := w.WaitIO()
+                results, err := w.WaitIO(nil)
                 if err != nil {
                         log.Println(err)
                         return
@@ -124,6 +124,27 @@ func main() {
 
 ```
 
+Notice that in the example above, ```Watcher.WaitIO()``` will allocate a slice object each time as the returned value. To eliminate these allocations, you can reuse the returned slice in this way:
+
+```go
+func server(w *gaio.Watcher) {
+        var reused []gaio.OpResult
+        for {
+                results, err := w.WaitIO(reused)
+                if err != nil {
+                        log.Println(err)
+                        return
+                }
+                for _, res := range results {
+                        // do something...
+                }
+                if results != nil {
+                        reused = results[:0]
+                }
+        }
+}
+```
+
 ### More examples
 
 <details>
@@ -166,7 +187,7 @@ func main() {
         // watcher.WaitIO goroutine
         go func() {
                 for {
-                        results, err := w.WaitIO()
+                        results, err := w.WaitIO(nil)
                         if err != nil {
                                 log.Println(err)
                                 return

--- a/aio_test.go
+++ b/aio_test.go
@@ -46,7 +46,7 @@ func echoServer(t testing.TB, bufsize int) net.Listener {
 	// ping-pong scheme echo server
 	go func() {
 		for {
-			results, err := w.WaitIO()
+			results, err := w.WaitIO(nil)
 			if err != nil {
 				log.Println(err)
 				return
@@ -206,7 +206,7 @@ func TestUnsupportedConn(t *testing.T) {
 	w.Read(nil, p2, make([]byte, 1))
 
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 		}
@@ -252,7 +252,7 @@ func testSingleDeadline(t *testing.T, w *Watcher) {
 
 READTEST:
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			break READTEST
@@ -283,7 +283,7 @@ READTEST:
 
 WRITETEST:
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			break WRITETEST
@@ -371,7 +371,7 @@ func testBidirectionWatcher(t *testing.T, w *Watcher) {
 	}()
 
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -434,7 +434,7 @@ func TestReadFull(t *testing.T) {
 	}
 
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -485,7 +485,7 @@ func TestSocketClose(t *testing.T) {
 		log.Fatal(err)
 	}
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -531,7 +531,7 @@ func TestWriteOnClosedConn(t *testing.T) {
 	}()
 
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -615,7 +615,7 @@ func testParallel(t *testing.T, par int, msgsize int) {
 	nbytes := 0
 	ntotal := msgsize * par
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -689,7 +689,7 @@ func testParallelRandomInternal(t *testing.T, par int, msgsize int, allswap bool
 	nbytes := 0
 	ntotal := msgsize * par
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -776,7 +776,7 @@ func testDeadline(t *testing.T, par int) {
 
 	nerrs := 0
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			t.Log(err)
 			return
@@ -871,7 +871,7 @@ func benchmarkEcho(b *testing.B, bufsize int, numconn int) {
 	count := 0
 	target := bufsize * b.N * numconn
 	for {
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			b.Fatal("waitio:", err)
 			return

--- a/examples/echo-server/main.go
+++ b/examples/echo-server/main.go
@@ -12,7 +12,7 @@ import (
 func echoServer(w *gaio.Watcher) {
 	for {
 		// loop wait for any IO events
-		results, err := w.WaitIO()
+		results, err := w.WaitIO(nil)
 		if err != nil {
 			log.Println(err)
 			return

--- a/examples/push-server/main.go
+++ b/examples/push-server/main.go
@@ -33,7 +33,7 @@ func main() {
 	// watcher.WaitIO goroutine
 	go func() {
 		for {
-			results, err := w.WaitIO()
+			results, err := w.WaitIO(nil)
 			if err != nil {
 				log.Println(err)
 				return

--- a/watcher.go
+++ b/watcher.go
@@ -178,8 +178,8 @@ func (w *watcher) notifyPending() {
 }
 
 // WaitIO blocks until any read/write completion, or error.
-// An internal 'buf' returned or 'r []OpResult' are safe to use BEFORE next call to WaitIO().
-func (w *watcher) WaitIO() (r []OpResult, err error) {
+// An internal 'buf' returned or '[]OpResult' are safe to use BEFORE next call to WaitIO().
+func (w *watcher) WaitIO(r []OpResult) ([]OpResult, error) {
 	// recycle previous aiocb
 	for k := range w.recycles {
 		aiocbPool.Put(w.recycles[k])


### PR DESCRIPTION
每次调用`WaitIO()`都会新创建一个`[]OpResult`小对象，对性能造成一定影响；这个PR修改了`WaitIO()`的接口，允许用户传入一个预先分配好的slice，从而避免每次重新创建。

```go
buf := make([]gaio.OpResult, 0, 100)
for {
  results, err := w.WaitIO(buf)
  ...
}
```

甚至用户可以直接重用返回的slice

```go
buf := make([]gaio.OpResult, 0, 100)
for {
  results, err := w.WaitIO(buf)
  for _, r := range results {
    // ...
  }
  buf = results[:0]
}
```

![image](https://user-images.githubusercontent.com/2639200/133776844-514299b9-e723-47ec-a546-25a3ad49dcf0.png)