### PR TITLE
fix: aiocb memory leak

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -1,4 +1,5 @@
 //go:build linux || darwin || netbsd || freebsd || openbsd || dragonfly
+// +build linux darwin netbsd freebsd openbsd dragonfly
 
 // Package gaio is an Async-IO library for Golang.
 //
@@ -183,6 +184,8 @@ func (w *watcher) WaitIO() (r []OpResult, err error) {
 	// recycle previous aiocb
 	for k := range w.recycles {
 		aiocbPool.Put(w.recycles[k])
+		// avoid memory leak
+		w.recycles[k] = nil
 	}
 	w.recycles = w.recycles[:0]
 
@@ -194,6 +197,8 @@ func (w *watcher) WaitIO() (r []OpResult, err error) {
 			for len(w.chResults) > 0 {
 				pcb := <-w.chResults
 				r = append(r, OpResult{Operation: pcb.op, Conn: pcb.conn, IsSwapBuffer: pcb.useSwap, Buffer: pcb.buffer, Size: pcb.size, Error: pcb.err, Context: pcb.ctx})
+				// avoid memory leak
+				pcb.ctx = nil
 				w.recycles = append(w.recycles, pcb)
 			}
 
@@ -437,6 +442,9 @@ func (w *watcher) loop() {
 			// swap w.pending with w.pending2
 			w.pendingMutex.Lock()
 			w.pendingCreate, w.pendingProcessing = w.pendingProcessing, w.pendingCreate
+			for i := 0; i < len(w.pendingCreate); i++ {
+				w.pendingCreate[i] = nil
+			}
 			w.pendingCreate = w.pendingCreate[:0]
 			w.pendingMutex.Unlock()
 			w.handlePending(w.pendingProcessing)

--- a/watcher.go
+++ b/watcher.go
@@ -193,6 +193,8 @@ func (w *watcher) WaitIO() (r []OpResult, err error) {
 		select {
 		case pcb := <-w.chResults:
 			r = append(r, OpResult{Operation: pcb.op, Conn: pcb.conn, IsSwapBuffer: pcb.useSwap, Buffer: pcb.buffer, Size: pcb.size, Error: pcb.err, Context: pcb.ctx})
+			// avoid memory leak
+			pcb.ctx = nil
 			w.recycles = append(w.recycles, pcb)
 			for len(w.chResults) > 0 {
 				pcb := <-w.chResults


### PR DESCRIPTION

`aiocb`中引用`ctx`并没有解除引用，只有

```go
w.pendingCreate = w.pendingCreate[:0]
```

底层数组没有变化，可能还存在对ctx的引用